### PR TITLE
Fix unidoces

### DIFF
--- a/IE9.js
+++ b/IE9.js
@@ -425,7 +425,8 @@ var Parser = RegGrp.extend({ignoreCase: true});
 var SINGLE_QUOTES       = /'/g,
     ESCAPED             = /'(\d+)'/g,
     ESCAPE              = /\\/g,
-    UNESCAPE            = /\\([nrtf'"])/g;
+    UNESCAPE            = /\\([nrtf'"])/g,
+    UNICODE             = /\\([\da-fA-F]{1,4})/g;
 
 var strings = [];
 
@@ -454,6 +455,9 @@ function decode(query) {
 function encodeString(string) {
   var index = strings.length;
   strings[index] = string.slice(1, -1)
+    .replace(UNICODE, function(match, chr) {
+        return eval("'\\u" + "0000".slice(chr.length) + chr + "'");
+    })
     .replace(UNESCAPE, "$1")
     .replace(SINGLE_QUOTES, "\\'");
   return "'" + index + "'";


### PR DESCRIPTION
When using [Font Awesome](http://fortawesome.github.io/Font-Awesome/), it uses the CSS attribute `content` to add an unicode content into the html element so it will use the proper font icon when the browser displays the element.

Before the fix:
![screen shot 2015-05-12 at 3 48 38 pm](https://cloud.githubusercontent.com/assets/813042/7595923/5a29413c-f8c0-11e4-9830-e52e0d393c26.png)

After:
![screen shot 2015-05-12 at 3 52 24 pm](https://cloud.githubusercontent.com/assets/813042/7595927/607245b6-f8c0-11e4-9bbb-b04332fc3084.png)

PS: I haven't update the file `ie9.min.js` because I don't know which library you're using to generate that version.
